### PR TITLE
issue template added #31

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,39 @@
+name: 🐞 Bug Report
+description: File a bug report
+title: '[Bug]: '
+labels: ['🛠 goal: fix', '🚦status: awaiting triage']
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      placeholder: Add descriptions
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      placeholder: Add screenshots
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Brave
+        - Other
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,30 @@
+name: 🔖 Documentation update
+description: Improve Documentation
+title: '[Docs]: '
+labels: ['📄 aspect: text', '🚦status: awaiting triage']
+body:
+  - type: textarea
+    id: improve-docs
+    attributes:
+      label: what's wrong in the documentation?
+      description: which things do we need to add?
+      placeholder: Add description
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      description: Add screenshots to see the demo
+      placeholder: Add screenshots
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,27 @@
+name: ✨ Feature Request
+description: Suggest a feature request
+title: '[Feat]: '
+labels: ['⭐ goal: addition', '🚦status: awaiting triage']
+body:
+  - type: textarea
+    id: what-feature
+    attributes:
+      label: What feature?
+      placeholder: Add descriptions
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Add screenshots
+      placeholder: Add screenshots
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
- added issue template 
@AlphaDecodeX please add labels so that we can add labels for specific issues
## solved #31 

## Also, check this guide for labels https://opensource.creativecommons.org/contributing-code/repo-labels/